### PR TITLE
Move javascript-getting-started to javascript

### DIFF
--- a/_javascript/getting_started.md
+++ b/_javascript/getting_started.md
@@ -7,8 +7,6 @@ Our official JS toolkit Steem.js makes is easy to access the steem blockchain fo
 
 The toolkit is located at: [https://github.com/steemit/steem-js](https://github.com/steemit/steem-js). 
 
-Documentation to get going is located in the [Javascript Section](#javascriptgetting_started).
- 
 Get running with Steem.js with a few simple options. 
 
 NPM install for Javascript projects. 

--- a/_javascript/getting_started.md
+++ b/_javascript/getting_started.md
@@ -3,7 +3,12 @@ title: Getting Started
 position: 1
 ---
 
-Steem.js makes is easy to access the steem blockchain for your project. 
+Our official JS toolkit Steem.js makes is easy to access the steem blockchain for your project. The Javascript library let's your app easily access steem blockchain data and also perform user actions.
+
+The toolkit is located at: [https://github.com/steemit/steem-js](https://github.com/steemit/steem-js). 
+
+Documentation to get going is located in the [Javascript Section](#javascriptgetting_started).
+ 
 Get running with Steem.js with a few simple options. 
 
 NPM install for Javascript projects. 


### PR DESCRIPTION
Move the javascript "QUICKSTART" information into the "JAVASCRIPT" section.

A separate PR will be made to update the quick tart section.