### PR TITLE
Add testnet details

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ collections:
     position: 6
   community:
     title: Community
-    position: 78
+    position: 7
 
 
 gems:

--- a/_config.yml
+++ b/_config.yml
@@ -23,9 +23,12 @@ collections:
   services:
     title: Services
     position: 5
+  testnet:
+    title: TestNet
+    position: 6
   community:
     title: Community
-    position: 6
+    position: 78
 
 
 gems:

--- a/_testnet/_defaults.md
+++ b/_testnet/_defaults.md
@@ -1,0 +1,7 @@
+---
+title:
+position:
+type:
+description:
+right_code:
+---

--- a/_testnet/testnet.md
+++ b/_testnet/testnet.md
@@ -1,0 +1,9 @@
+---
+title: testnet
+position: 1
+---
+
+The testnet is an alternative Steem block chain, to be used for testing. Testnet coins are separate and distinct from actual steem, and are never supposed to have any value. This allows application developers or steem testers to experiment, without having to use real steem currency or worrying about breaking the main steem chain. In addition
+to testing each user is awared with enough steem on testnet so that they can experiment without any bandwidth issues.
+
+The testnet backend is available at [https://testnet.steem.vc/](https://testnet.steem.vc/) and is maintained by [https://steemit.com/@almost-digital](https://steemit.com/@almost-digital). The condenser version or the front end for the same is also available at [https://condenser.steem.vc/](https://condenser.steem.vc/) The account creation is disabled on the condenser and can only be created from the backend using curl or http call. You can get the details for the same from [https://testnet.steem.vc/](https://testnet.steem.vc/)


### PR DESCRIPTION
Adding Steem test net details. This should help a lot of Steem Developers as developing without a readily available testnet can be very comburesome.