### PR TITLE
Fix community section indexes

### DIFF
--- a/_community/overview.md
+++ b/_community/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-position: 2
+position: 1
 ---
 
 The steem community is thriving with developer activity and projects to support

--- a/_community/steemdata.md
+++ b/_community/steemdata.md
@@ -1,6 +1,6 @@
 ---
-title: MongoDB 
-position: 3
+title: SteemData
+position: 4
 ---
 
 SteemData helps developers and researchers build better STEEM applications. We parse the STEEM blockchain for you, and provide the data as a fast and convenient MongoDB service.

--- a/_community/steemsql.md
+++ b/_community/steemsql.md
@@ -1,6 +1,6 @@
 ---
-title: steemSQL
-position: 2
+title: SteemSQL
+position: 3
 ---
 
 A public Microsoft SQL server database with steem blockchain data. 


### PR DESCRIPTION
The indexes that set the order for the sections within the community section were not done correctly. This PR updates them so that they are ordered 1-4 and there is no overlap. It also renames the "MongoDB" section to "SteemData" since that is the application name.