### PR TITLE
Fix duplicate in the Governance section

### DIFF
--- a/_data/glossary/index.yml
+++ b/_data/glossary/index.yml
@@ -48,8 +48,6 @@
       def: Servers running blockchain software
     - term: Witness
       def: Witness is a position/role for the people who are chosen by community (delegate trust) to support platform and run consensus protocol to ensure security and validity of transactions/blocks on the blockchain
-    - term: Node
-      def: Servers running blockchain software
     - term: Hardfork
       def: Process to release protocol/blockchain consensus upgrades
     - term: Softfork


### PR DESCRIPTION
The term `Node` was duplicated in the *Governance* section. I removed the second one.