### PR TITLE
Update public RPC nodes list

### DIFF
--- a/_quickstart/steemd_nodes.md
+++ b/_quickstart/steemd_nodes.md
@@ -25,11 +25,13 @@ Applications that interface directly with the Steem blockchain will need to conn
 
 |URL|Owner|
 |---|---|
-|gtg.steem.house:8090|@gtg|
+|api.steemit.com|@steemit|
+|api.steem.house|@gtg|
 |steemd.minnowsupportproject.org|@followbtcnews|
+|steemd.pevo.science|@pharesim|
 |steemd.privex.io|@privex|
 |steemd.steemgigs.org|@steemgigs|
-|steemd.steemit.com|@steemit|
+|rpc.buildteam.io|@themarkymark|
 |rpc.curiesteem.com|@curie|
 |rpc.steemliberator.com|@netuoso|
 |rpc.steemviz.com|@ausbitbank|


### PR DESCRIPTION
This PR makes four changes to the public RPC nodes list:
- Changes `steemd.steemit.com` to `api.steemit.com`
- Changes `gtg.steem.house:8090` to `api.steem.house`
- Adds `steemd.pevo.science`
- Adds `rpc.buildteam.io`
