### PR TITLE
[#304] fix large text at bottom of tutorials if newline missing from …

### DIFF
--- a/lib/scrape/tutorials_job/base.rb
+++ b/lib/scrape/tutorials_job/base.rb
@@ -60,6 +60,7 @@ module Scrape
               <br>
 
               #{rewrite_relative_links(rewrite_images body, include_name)}
+
               ---
               
               


### PR DESCRIPTION
Closes #304 