### PR TITLE
Useful rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'neatjson'
 gem 'rake'
 gem 'git'
 gem 'steem-ruby'
+gem 'html-proofer'
 
 group :jekyll_plugins do
   gem 'jekyll-seo-tag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.1.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     bitcoin-ruby (0.0.18)
     colorator (1.1.0)
+    colorize (0.8.1)
     concurrent-ruby (1.0.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.9.25)
     forwardable-extended (2.6.0)
     git (1.5.0)
     hashie (3.6.0)
+    html-proofer (3.9.3)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.8.1)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -50,8 +67,13 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     mercenary (0.3.6)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
     multi_json (1.13.1)
     neatjson (0.8.4)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
@@ -73,12 +95,19 @@ GEM
       hashie (~> 3.5, >= 3.5.7)
       json (~> 2.1, >= 2.1.0)
       logging (~> 2.2, >= 2.2.0)
+    thread_safe (0.3.6)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   git
+  html-proofer
   jekyll
   jekyll-seo-tag
   jekyll-sitemap

--- a/Rakefile
+++ b/Rakefile
@@ -107,6 +107,26 @@ namespace :production do
   end
 end
 
+desc 'Dump all operation types.  Useful for schema comparison.'
+task :ops_dump, [:vops, :appbase] do |t, args|
+  vops = args[:vops] == 'true'
+  appbase = args[:appbase] == 'true'
+  file_name = '_data/apidefinitions/broadcast_ops.yml'
+  op_names = []
+  yaml = YAML.load_file(file_name)
+  op_names += yaml[0]['ops'].map do |op|
+    next if op['virtual'] && !vops
+    
+    if !!appbase
+      op['name'] + '_operation'
+    else
+      op['name']
+    end
+  end
+  
+  puts op_names.compact.sort
+end
+
 namespace :test do
   KNOWN_APIS = %i(
     account_by_key_api account_history_api block_api condenser_api 

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ require 'rake/testtask'
 require 'net/https'
 require 'json'
 require 'yaml'
+require 'html-proofer'
 
 namespace :scrape do
   desc "Scrape steemjs docs"
@@ -200,5 +201,21 @@ namespace :test do
     end
     
     exit smoke
+  end
+  
+  desc 'Want some work to do?  Run this report and get busy.'
+  task :proof do
+    # See: https://github.com/gjtorikian/html-proofer#configuration
+    sh 'bundle exec jekyll build'
+    options = {
+      assume_extension: true,
+      only_4xx: true,
+      check_favicon: true,
+      check_html: true,
+      allow_hash_href: true,
+      empty_alt_ignore: true
+    }
+    
+    HTMLProofer.check_directory("./_site", options).run
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -106,6 +106,11 @@ namespace :production do
     
     exit(0)
   end
+  
+  desc "Make a clean build."
+  task :clean do
+    sh 'rm -rf _site && rm -rf docs && git checkout -- docs && git checkout -- _site'
+  end
 end
 
 desc 'Dump all operation types.  Useful for schema comparison.'


### PR DESCRIPTION
I've provided a few useful `rake` tasks for the Developer Portal.  They're mostly just for housekeeping tasks to keep up with continued changes over time.

### ops_dump

This task outputs all known ops, except virtual ops.  We can use this to find undocumented ops.  We can save the output to the project and run it later to find differences in new runs.

```bash
rake ops_dump # 
```

Just like above the previous example, but this will included virtual ops in the results.

```bash
rake ops_dump[true]
```

Just like above the previous example, but uses appbase naming (maybe this should be the default behavior some day).

```bash
rake ops_dump[true,true]
```

### test:proof

Checks the HTML generated by Jekyll and other assets to find problems.  In particular, it locates issues in HTML like duplicate IDs.  Mostly helps avoid issues that can impact dynamic features.

This task uses the [`html-proofer`](https://github.com/gjtorikian/html-proofer) gem and can be configured to be more or less opinionated.  Currently, it's configured to look at:

```ruby
["ImageCheck", "HtmlCheck", "ScriptCheck", "FaviconCheck", "LinkCheck"]
```

```bash
rake test:proof
```