### PR TITLE
Update Node.js version in JS tutorial

### DIFF
--- a/_tutorials-javascript/getting_started.md
+++ b/_tutorials-javascript/getting_started.md
@@ -18,7 +18,7 @@ You can still learn a lot of these if they aren't in your base skill-set; it'll 
 
 ### Your Dev Environment
 
-These tutorials require [Node.js 8.7+](https://nodejs.org/en/download/). [Yarn](https://yarnpkg.com/en/) is nice, but not required. Runnable versions of the tutorials are located [in this github repo](https://github.com/steemit/devportal-tutorials-js).
+These tutorials require [Node.js 8.9+](https://nodejs.org/en/download/). [Yarn](https://yarnpkg.com/en/) is nice, but not required. Runnable versions of the tutorials are located [in this github repo](https://github.com/steemit/devportal-tutorials-js).
 If you haven't chosen an editor, you can use [Atom](https://atom.io/), [Sublime](https://www.sublimetext.com/), [Intellij](https://www.jetbrains.com/idea/), [Vi](https://en.wikipedia.org/wiki/Vi), etc.
 
 If you want to keep multiple versions of Node on your system try [Node Version Manager](https://github.com/creationix/nvm).


### PR DESCRIPTION
If we use Node.js 8.7.0 version, we get following an error message.

```
error webpack-serve@2.0.3: The engine "node" is incompatible with this module. Expected version ">= 6.9.0 < 7.0.0 || >= 8.9.0". Got "8.7.0"
error Found incompatible module
```

It is better to update the document to avoid this error.