### PR TITLE
Blockchain includes

### DIFF
--- a/_layouts/steem-post.html
+++ b/_layouts/steem-post.html
@@ -1,6 +1,20 @@
 ---
 layout: default
 ---
-<div class="steem-content">
-  {{ content }}
-</div>
+<section id="{{page.id | slugify}}" class="row {{ page.id | slugify }}">
+  <h3>
+    <a id="{{ page.id | slugify }}">
+      {{ page.title }}
+      {% if page.type %}
+        <span class="endpoint {{ page.type }}"></span>
+      {% endif %}
+    </a>
+  </h3>
+  {% if page.description %}
+    <span class="description">{{page.description | markdownify}}</span>
+  {% endif %}
+
+  <div class="steem-content">
+    {{ content }}
+  </div>
+</section>

--- a/_layouts/steem-post.html
+++ b/_layouts/steem-post.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<div class="steem-content">
+  {{ content }}
+</div>

--- a/_plugins/post_generator.rb
+++ b/_plugins/post_generator.rb
@@ -1,0 +1,31 @@
+require 'steem'
+
+module Jekyll
+  module SteemPostGenerator
+    def steem_post(slug)
+      slug = slug.split('@').last
+      slug = slug.split('/')
+      author = slug[0]
+      permlink = slug[1..-1].join('/')
+      permlink = permlink.split('?').first
+      permlink = permlink.split('#').first
+      api = Steem::CondenserApi.new
+      
+      api.get_content(author, permlink) do |content|
+        content.body + <<~DONE
+        \n<hr />
+        <p>
+          See: <a href="https://steemit.com/@#{author}/#{permlink}">#{content.title}</a>
+          by
+          <a href="https://steemit.com/@#{author}">@#{author}</a>
+        </p>
+        DONE
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::SteemPostGenerator)
+
+# USAGE:
+# {{'@stoodkev/how-to-set-up-and-use-multisignature-accounts-on-steem-blockchain' | steem_post}}

--- a/_plugins/post_generator.rb
+++ b/_plugins/post_generator.rb
@@ -12,7 +12,30 @@ module Jekyll
       api = Steem::CondenserApi.new
       
       api.get_content(author, permlink) do |content|
-        content.body + <<~DONE
+        body = content.body
+        
+        # This will normalize image hoster proxy URLs that the author copied
+        # from another post.
+        
+        body = body.gsub(/https:\/\/steemitimages.com\/[0-9]+x0\/https:\/\//, 'https://')
+        
+        # Although it works on steemit.com and many other markdown interpretors,
+        # kramdown doesn't like this, so we have to fix it:
+        # 
+        # <div>
+        #   This *won't* work.
+        # </div>
+        #
+        # See: https://stackoverflow.blog/2008/06/25/three-markdown-gotcha/
+        
+        body = body.gsub(/<([^\/].+)>(.+)<\/\1>/m) do
+          match = Regexp.last_match
+          html = Kramdown::Document.new(match[2]).to_html
+          
+          "<#{match[1]}>#{html.gsub("\n", "<br />")}</#{match[1]}>"
+        end
+        
+        body + <<~DONE
         \n<hr />
         <p>
           See: <a href="https://steemit.com/@#{author}/#{permlink}">#{content.title}</a>

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -599,3 +599,8 @@ blockquote {
 	background: #EEEEEE;
 	padding:5px;
 }
+
+.steem-content {
+  width: 60%;
+  padding: 0 12px;
+}

--- a/_tutorials-recipes/using-multisignatire-accounts.md
+++ b/_tutorials-recipes/using-multisignatire-accounts.md
@@ -6,4 +6,4 @@ exclude: true
 layout: steem-post
 ---
 
-{{'@stoodkev/how-to-set-up-and-use-multisignature-accounts-on-steem-blockchain' | steem_post}}
+{{'@crokkon/steem-multi-signature-transaction-guide-for-beem-python-1546636997324' | steem_post}}

--- a/_tutorials-recipes/using-multisignatire-accounts.md
+++ b/_tutorials-recipes/using-multisignatire-accounts.md
@@ -1,0 +1,9 @@
+---
+title: Using Multisignature Accounts
+position: 1
+description: How to set up and use multisignature accounts on Steem Blockchain.
+exclude: true
+layout: steem-post
+---
+
+{{'@stoodkev/how-to-set-up-and-use-multisignature-accounts-on-steem-blockchain' | steem_post}}


### PR DESCRIPTION
*As a devportal maintainer, I would like the ability to include specific content that has been published on the Steem Blockchain, so that this content can be hosted and searchable on the developer portal.*

This pull request includes:

* A small layout for Steem Posts (`_layouts/steem-post.html`) which uses a css class called `steem-post`.
* A change to `_sass/_main.scss` to define the `steem-post` class.
* A tutorial stub (`_tutorials-recipes/using-multisignatire-accounts.md`) that references an  excellent tutorial on the blockchain to demonstrate this functionality.
* A new generator (`_plugins/post_generator.rb`) that looks for a liquid tag for inserting a Steem Blockchain post.

Together, this change allows content on the blockchain to import on pages that use this new liquid tag:

```liquid
{{'@stoodkev/how-to-set-up-and-use-multisignature-accounts-on-steem-blockchain' | steem_post}}
```

... which generates (area in red):

![image](https://user-images.githubusercontent.com/494368/50722620-90a67180-1086-11e9-9703-b6e5060ebde6.png)

The obvious advantage to this process is that previously published content can be included easily on the devportal.  The content is generated each time `jekyll build` executes.  If the post is modified, `jekyll build` must be executed again to pick up the changes.