### PR TITLE
Added environment variables for deploy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,14 @@ namespace :production do
   end
   
   task :build do
-    sh 'bundle exec jekyll build --destination docs'
+    baseurl = ENV.fetch('BASEURL', '/')
+    cmd = 'bundle exec jekyll build --destination docs'
+    
+    if !!baseurl && baseurl != '/'
+      cmd += " --baseurl #{baseurl}"
+    end
+    
+    sh cmd
   end
   
   task :drop_previous_build do
@@ -91,9 +98,11 @@ namespace :production do
   
   desc "Deploy current master to GH Pages"
   task deploy: [:prevent_dirty_builds, :drop_previous_build, :build] do
+    remote = ENV.fetch('REMOTE', 'origin')
+    
     sh 'git add -A'
     sh 'git commit -m "jekyll base sources"'
-    sh 'git push origin master'
+    sh "git push #{remote} master"
     
     exit(0)
   end


### PR DESCRIPTION
*As a devportal maintainer, I would like to be able to use `rake production:deploy` without having to modify the `Rakefile` and `_config.yml` files, so I don't interfere with the deploy process of other forks.*

This change allows forks to deploy on their own github remotes and baseurls.  Taking the defaults should not interfere with Steemit, Inc.'s deploy process.

To override the remote and baseurl options:

```bash
REMOTE="experimental" BASEURL="/devportal" rake production:deploy
```

To continue to use the defaults:

```bash
rake production:deploy
```