### PR TITLE
Smoke test hivemind error check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -192,6 +192,11 @@ namespace :test do
                 smoke += 1
                 print "\n\t#{data['error']['message']}\n"
               end
+            elsif !!data['result'] && data['result'].class == ::Hash && !!data['result']['error']
+              # Capture errors provided by hivemind.
+              
+              smoke += 1
+              print "\n\t#{data['result']['error']['message']}\n"
             else
               print '√'
             end


### PR DESCRIPTION
Smoke tests didn't notice certain problems because, prior to this pull request, it only expects an `error` key in the json response.  Turns out errors were being reported by hivemind in `result`, when running:

```bash
bundle exec rake test:curl[condenser_api]
```

After applying this PR, the following examples will be visible:

### Examples

This example is ok because if you try it, you see a good explanation.  Try a different node and it works ...

![image](https://user-images.githubusercontent.com/494368/51769160-21c1a480-2097-11e9-9637-4a38b80a468d.png)

These are fine as well, since it's clear why it's not working:

![image](https://user-images.githubusercontent.com/494368/51769186-3b62ec00-2097-11e9-93a3-34be087d93ad.png)

But these are a problem because the parameter signature changed:

![image](https://user-images.githubusercontent.com/494368/51769218-5d5c6e80-2097-11e9-917f-9c1b3458cac7.png)

---

That last result was reported to @roadscape, which lead to: https://github.com/steemit/hivemind/issues/183