### PR TITLE
canonical_url to header section

### DIFF
--- a/_tutorials-recipes/using-multisignatire-accounts.md
+++ b/_tutorials-recipes/using-multisignatire-accounts.md
@@ -4,6 +4,7 @@ position: 1
 description: How to set up and use multisignature accounts on Steem Blockchain.
 exclude: true
 layout: steem-post
+canonical_url: https://steemit.com/utopian-io/@crokkon/steem-multi-signature-transaction-guide-for-beem-python-1546636997324
 ---
 
 {{'@crokkon/steem-multi-signature-transaction-guide-for-beem-python-1546636997324' | steem_post}}


### PR DESCRIPTION
Small change to page header so that the `canonical_url` points to the original article.

See: https://github.com/inertia186/devportal/issues/19