### PR TITLE
added method/op names to the top of each section

### DIFF
--- a/_apidefinitions/block-api.md
+++ b/_apidefinitions/block-api.md
@@ -1,5 +1,5 @@
 ---
-position: 10
+position: 3
 exclude: true
 ---
 

--- a/_apidefinitions/broadcast-ops.md
+++ b/_apidefinitions/broadcast-ops.md
@@ -3,6 +3,30 @@ position: 99
 exclude: true
 ---
 
+Ops:
+<ul>
+{% for sections in site.data.apidefinitions.broadcast_ops %}
+{% assign sorted_ops = sections.ops | sort: 'name' %}
+{% for op in sorted_ops %}
+{% unless op.virtual %}
+<li class="button"><a href="#broadcast_ops_{{ op.name | slug}}">{{op.name | split: '.' | last}}</a></li> 
+{% endunless %}
+{% endfor %}
+{% endfor %}
+</ul>
+
+Virtual Ops:
+<ul>
+{% for sections in site.data.apidefinitions.broadcast_ops %}
+{% assign sorted_ops = sections.ops | sort: 'name' %}
+{% for op in sorted_ops %}
+{% if op.virtual %}
+<li class="button"><a href="#broadcast_ops_{{ op.name | slug}}">{{op.name | split: '.' | last}}</a></li>
+{% endif %}
+{% endfor %}
+{% endfor %}
+</ul>
+
 {% for sections in site.data.apidefinitions.broadcast_ops %}
 {{ sections.description | liquify | markdownify }}
 {% for op in sections.ops %}

--- a/_apidefinitions/database-api.md
+++ b/_apidefinitions/database-api.md
@@ -1,5 +1,5 @@
 ---
-position: 3
+position: 4
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.database_api %}

--- a/_apidefinitions/debug-node-api.md
+++ b/_apidefinitions/debug-node-api.md
@@ -1,5 +1,5 @@
 ---
-position: 11
+position: 5
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.debug_node_api %}

--- a/_apidefinitions/follow-api.md
+++ b/_apidefinitions/follow-api.md
@@ -1,5 +1,5 @@
 ---
-position: 4
+position: 6
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.follow_api %}

--- a/_apidefinitions/jsonrpc.md
+++ b/_apidefinitions/jsonrpc.md
@@ -1,5 +1,5 @@
 ---
-position: 5
+position: 7
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.jsonrpc %}

--- a/_apidefinitions/market-history-api.md
+++ b/_apidefinitions/market-history-api.md
@@ -1,5 +1,5 @@
 ---
-position: 6
+position: 8
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.market_history_api %}

--- a/_apidefinitions/network-broadcast-api.md
+++ b/_apidefinitions/network-broadcast-api.md
@@ -1,5 +1,5 @@
 ---
-position: 7
+position: 9
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.network_broadcast_api %}

--- a/_apidefinitions/rc-api.md
+++ b/_apidefinitions/rc-api.md
@@ -1,5 +1,5 @@
 ---
-position: 8
+position: 10
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.rc_api %}

--- a/_apidefinitions/reputation-api.md
+++ b/_apidefinitions/reputation-api.md
@@ -1,5 +1,5 @@
 ---
-position: 9
+position: 11
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.reputation_api %}

--- a/_apidefinitions/rewards-api.md
+++ b/_apidefinitions/rewards-api.md
@@ -1,5 +1,5 @@
 ---
-position: 10
+position: 12
 exclude: true
 ---
 

--- a/_apidefinitions/tags-api.md
+++ b/_apidefinitions/tags-api.md
@@ -1,5 +1,5 @@
 ---
-position: 10 
+position: 13 
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.tags_api %}

--- a/_apidefinitions/transaction-status-api.md
+++ b/_apidefinitions/transaction-status-api.md
@@ -1,5 +1,5 @@
 ---
-position: 11
+position: 14
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.transaction_status_api %}

--- a/_apidefinitions/witness-api.md
+++ b/_apidefinitions/witness-api.md
@@ -1,5 +1,5 @@
 ---
-position: 12
+position: 15
 exclude: true
 ---
 {% include api-template.html api_data=site.data.apidefinitions.witness_api %}

--- a/_includes/api-template.html
+++ b/_includes/api-template.html
@@ -1,3 +1,13 @@
+Methods:
+<ul>
+{% for sections in include.api_data %}
+{% assign sorted_methods = sections.methods | sort: 'api_method' %}
+{% for method in sorted_methods %}
+<li class="button"><a href="#{{ method.api_method | slug}}">{{method.api_method | split: '.' | last}}</a></li>
+{% endfor %}
+{% endfor %}
+</ul>
+
 {% for sections in include.api_data %}
 {{ sections.description | liquify | markdownify }}
 {% for method in sections.methods %}

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -160,6 +160,19 @@ dl dd:after {
 	height: 0;
 }
 
+.button {
+  background-color: #ddd;
+  border: none;
+  color: black;
+  padding: 5px 10px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  margin: 2px 1px;
+  cursor: pointer;
+  border-radius: 8px;
+}
+
 .sidebar h6 {
 	text-transform: uppercase;
 	line-height: 1em;


### PR DESCRIPTION
This pull request will add navigation links to make it easy for devs to find related methods in a particular namespace, e.g.:

![image](https://user-images.githubusercontent.com/494368/68429343-c151ae80-0162-11ea-9ae0-c73e279bcf56.png)

See: https://github.com/inertia186/devportal/issues/26